### PR TITLE
internal/graph: Don't backtrack

### DIFF
--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -63,17 +63,17 @@ func IsAcyclic(g Graph) (bool, []int) {
 // For example, running isAcyclic starting from 1 on the following
 // graph will return 3.
 // 	1 -> 2 -> 3 -> 1
-func isAcyclic(g Graph, u int, info *cycleInfo, path []int) []int {
-	info.nodes[u].Visited = true
-	info.nodes[u].OnStack = true
+func isAcyclic(g Graph, u int, info cycleInfo, path []int) []int {
+	info[u].Visited = true
+	info[u].OnStack = true
 
 	path = append(path, u)
 	for _, v := range g.EdgesFrom(u) {
-		if !info.nodes[v].Visited {
+		if !info[v].Visited {
 			if cycle := isAcyclic(g, v, info, path); len(cycle) > 0 {
 				return cycle
 			}
-		} else if info.nodes[v].OnStack {
+		} else if info[v].OnStack {
 			// We've found a cycle, and we have a full path back.
 			// Prune it down to just the cyclic nodes.
 			cycle := path
@@ -88,7 +88,7 @@ func isAcyclic(g Graph, u int, info *cycleInfo, path []int) []int {
 			return append(cycle, v)
 		}
 	}
-	info.nodes[u].OnStack = false
+	info[u].OnStack = false
 	return nil
 }
 
@@ -98,25 +98,16 @@ type cycleNode struct {
 	OnStack bool
 }
 
-// cycleInfo contains helpful info for cycle detection.
-type cycleInfo struct {
-	// order is the number of nodes in the graph
-	order int
+// cycleInfo contains information about each node while we're trying to find
+// cycles.
+type cycleInfo []cycleNode
 
-	// nodes is the information for a given node.
-	nodes []cycleNode
+func newCycleInfo(order int) cycleInfo {
+	return make(cycleInfo, order+1) // +1 because 0 is sentinel value
 }
 
-func newCycleInfo(order int) *cycleInfo {
-	return &cycleInfo{
-		order: order,
-		// +1 because 0 is always a sentinel value.
-		nodes: make([]cycleNode, order+1),
-	}
-}
-
-func (info *cycleInfo) Reset() {
-	for i := 1; i < info.order; i++ {
-		info.nodes[i] = cycleNode{}
+func (info cycleInfo) Reset() {
+	for i := range info {
+		info[i] = cycleNode{}
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -64,6 +64,10 @@ func IsAcyclic(g Graph) (bool, []int) {
 // graph will return 3.
 // 	1 -> 2 -> 3 -> 1
 func isAcyclic(g Graph, u int, info cycleInfo, path []int) []int {
+	// We've already verified that there are no cycles from this node.
+	if info[u].Visited {
+		return nil
+	}
 	info[u].Visited = true
 	info[u].OnStack = true
 
@@ -108,6 +112,6 @@ func newCycleInfo(order int) cycleInfo {
 
 func (info cycleInfo) Reset() {
 	for i := range info {
-		info[i] = cycleNode{}
+		info[i].OnStack = false
 	}
 }

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -42,41 +42,18 @@ func IsAcyclic(g Graph) (bool, []int) {
 	// cycleStart is a node that introduces a cycle in
 	// the graph. Values in the range [1, g.Order()) mean
 	// that there exists a cycle in g.
-	cycleStart := -1
 	info := newCycleInfo(g.Order())
 
-	for i := 1; i < g.Order(); i++ {
+	for i := 0; i < g.Order(); i++ {
 		info.Reset()
 
-		cycleStart = isAcyclic(g, i, info)
-		if cycleStart >= 0 {
-			break
+		cycle := isAcyclic(g, i, info, nil /* cycle path */)
+		if len(cycle) > 0 {
+			return false, cycle
 		}
 	}
 
-	if cycleStart < 0 {
-		return true, nil
-	}
-
-	// compute cycle path using backtrack
-	cycle := []int{cycleStart}
-	curr := cycleStart
-	for {
-		curr = info.nodes[curr].Backtrack
-		cycle = append(cycle, curr)
-		if curr == cycleStart {
-			break
-		}
-	}
-
-	// cycle is reverse-order.
-	i, j := 0, len(cycle)-1
-	for i < j {
-		cycle[i], cycle[j] = cycle[j], cycle[i]
-		i++
-		j--
-	}
-	return false, cycle
+	return true, nil
 }
 
 // isAcyclic traverses the given graph starting from a specific node
@@ -86,30 +63,39 @@ func IsAcyclic(g Graph) (bool, []int) {
 // For example, running isAcyclic starting from 1 on the following
 // graph will return 3.
 // 	1 -> 2 -> 3 -> 1
-func isAcyclic(g Graph, u int, info *cycleInfo) int {
+func isAcyclic(g Graph, u int, info *cycleInfo, path []int) []int {
 	info.nodes[u].Visited = true
 	info.nodes[u].OnStack = true
 
+	path = append(path, u)
 	for _, v := range g.EdgesFrom(u) {
 		if !info.nodes[v].Visited {
-			info.nodes[v].Backtrack = u
-			if start := isAcyclic(g, v, info); start >= 0 {
-				return start
+			if cycle := isAcyclic(g, v, info, path); len(cycle) > 0 {
+				return cycle
 			}
 		} else if info.nodes[v].OnStack {
-			info.nodes[v].Backtrack = u
-			return v
+			// We've found a cycle, and we have a full path back.
+			// Prune it down to just the cyclic nodes.
+			cycle := path
+			for i := len(cycle) - 1; i >= 0; i-- {
+				if cycle[i] == v {
+					cycle = cycle[i:]
+					break
+				}
+			}
+
+			// Complete the cycle by adding this node to it.
+			return append(cycle, v)
 		}
 	}
 	info.nodes[u].OnStack = false
-	return -1
+	return nil
 }
 
 // cycleNode keeps track of a single node's info for cycle detection.
 type cycleNode struct {
-	Visited   bool
-	OnStack   bool
-	Backtrack int
+	Visited bool
+	OnStack bool
 }
 
 // cycleInfo contains helpful info for cycle detection.

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -103,7 +103,7 @@ type cycleNode struct {
 type cycleInfo []cycleNode
 
 func newCycleInfo(order int) cycleInfo {
-	return make(cycleInfo, order+1) // +1 because 0 is sentinel value
+	return make(cycleInfo, order)
 }
 
 func (info cycleInfo) Reset() {

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -48,41 +48,41 @@ func TestGraphIsAcyclic(t *testing.T) {
 	testCases := []struct {
 		edges [][]int
 	}{
-		// 1
+		// 0
 		{
 			edges: [][]int{
 				nil,
 			},
 		},
-		// 1 --> 2 --> 3
+		// 0 --> 1 --> 2
 		{
 			edges: [][]int{
+				{1},
 				{2},
-				{3},
 				nil,
 			},
 		},
-		// 1 ---> 2 -------> 3
+		// 0 ---> 1 -------> 2
 		// |                 ^
 		// '-----------------'
 		{
 			edges: [][]int{
-				{2, 3},
-				{3},
+				{1, 2},
+				{2},
 				nil,
 			},
 		},
-		// 1 --> 2 --> 3    5 --> 6
+		// 0 --> 1 --> 2    4 --> 5
 		// |           ^    ^
 		// +-----------'    |
-		// '---------> 4 ---'
+		// '---------> 3 ---'
 		{
 			edges: [][]int{
-				{2, 3, 4},
-				{3},
+				{1, 2, 3},
+				{2},
 				nil,
+				{4},
 				{5},
-				{6},
 				nil,
 			},
 		},
@@ -90,7 +90,7 @@ func TestGraphIsAcyclic(t *testing.T) {
 	for _, tt := range testCases {
 		g := newTestGraph()
 		for i, neighbors := range tt.edges {
-			g.Nodes[i+1] = neighbors
+			g.Nodes[i] = neighbors
 		}
 		ok, cycle := IsAcyclic(g)
 		assert.True(t, ok, "expected acyclic, got cycle %v", cycle)

--- a/internal/graph/graph_test.go
+++ b/internal/graph/graph_test.go
@@ -103,9 +103,9 @@ func TestGraphIsCyclic(t *testing.T) {
 		cycle []int
 	}{
 		//
-		// 0 ---> 1 ---> 2
-		// ^             |
-		// '-------------'
+		// 0 ---> 1 ---> 2 ---> 3
+		// ^                    |
+		// '--------------------'
 		{
 			edges: [][]int{
 				{1},
@@ -113,7 +113,7 @@ func TestGraphIsCyclic(t *testing.T) {
 				{3},
 				{0},
 			},
-			cycle: []int{0, 1, 2, 3},
+			cycle: []int{0, 1, 2, 3, 0},
 		},
 		//
 		// 0 ---> 1 ---> 2
@@ -125,7 +125,7 @@ func TestGraphIsCyclic(t *testing.T) {
 				{2},
 				{1},
 			},
-			cycle: []int{1, 2},
+			cycle: []int{1, 2, 1},
 		},
 		//
 		// 0 ---> 1 ---> 2 ----> 3
@@ -139,7 +139,7 @@ func TestGraphIsCyclic(t *testing.T) {
 				{1, 3},
 				nil,
 			},
-			cycle: []int{1, 2},
+			cycle: []int{1, 2, 1},
 		},
 	}
 	for _, tt := range testCases {


### PR DESCRIPTION
We don't need to backtrack to figure out how we got to a cycle.
We can keep track as we recurse.

This helps simplify the implementation a bit,
and obviates the need to reverse the computed path later.

This also gives us the full path we took to find the cycle,
but I pruned it down to just the cycle to match prior behavior.

Finally, I changed the tests to assert the exact/full path of the cycle,
which required updating the test cases a little because they were not
previously validating that.

Additionally, I

- simplified the cycleInfo implementation because it doesn't need to be
  a struct or a pointer at this point.
- removed knowledge of sentinel nodes from internal/graph and its tests